### PR TITLE
Separate things to install via brew from script

### DIFF
--- a/home/.chezmoidata.toml
+++ b/home/.chezmoidata.toml
@@ -1,0 +1,105 @@
+# Contents of this file drives installation of software
+# .chezmoiscripts/run_onchange_before_brew-install.sh.tmpl
+# .chezmoiscripts/run_onchange_before_apt-install.sh.tmpl
+[all_os]
+brews = [
+  "go",
+  "fzf",
+  "dive",
+  "jq",
+  "git",
+  "htop",
+  "tree",
+  "curl",
+  "direnv",
+  "pandoc",
+  "ipcalc",
+  "powerline-go",
+  "terraform",
+  "terragrunt",
+  "packer",
+  "kubernetes-cli",
+  "kubectx",
+  "stern",
+  "k9s",
+  "vault",
+  "chezmoi",
+  "helm",
+  "pv",
+  "rustup-init",
+  "jrockway/tap/jlog",
+  "tealdeer",
+]
+full_brews = [
+  "ansible",
+  "awscli",
+  "azure-cli",
+  "openjdk@17",
+  "maven",
+  "pgcli",
+  "neo4j", # TODO need to verify that neo4j no longer needs admin access on a mac
+]
+taps = [
+  "jrockway/tap",
+]
+
+[mac_os]
+brews = [
+  "bash-completion",
+  "readline", # .inputrc
+  "watch",
+  "blueutil", # used by Hammerspoon scripts
+  "svn", # Needed by font-liberation-mono-for-powerline, for some reason
+]
+taps = [
+  "homebrew/cask-fonts", # For font-liberation-mono-for-powerline
+]
+casks = [
+  "hammerspoon",
+  "stats",
+  "firefox",
+  "google-chrome",
+  "visual-studio-code",
+  "jetbrains-toolbox",
+  "iterm2",
+  "keeweb",
+  "font-liberation-mono-for-powerline",
+  "slack",
+  # TODO Temporarily needed until https://github.com/Homebrew/homebrew-core/pull/97394
+  # Re-add `"dockutil"` to brews list when merged
+  "hpedrorodrigues/tools/dockutil",
+]
+full_casks = [
+  "google-cloud-sdk",
+  "drawio",
+  "libreoffice",
+  "gimp",
+  "inkscape",
+]
+
+[mac_os_admin]
+full_brews = [
+  "mas", # mas needs admin permissions depending on what it installs
+]
+full_casks = [
+  "docker",
+]
+
+[linux_os_admin]
+debs = [
+  "curl",
+  "git",
+  "fonts-powerline",
+  "gnome-tweaks",
+  "wl-clipboard",
+  "zsh",
+  "apt-transport-https", # needed to install vscode - https://code.visualstudio.com/docs/setup/linux#_debian-and-ubuntu-based-distributions
+  "code",
+  "build-essential",
+  "rclone",
+  "vim-runtime",
+  "vim-gui-common",
+]
+full_deps = [
+  "docker.io",
+]

--- a/home/.chezmoiscripts/run_onchange_before_apt-install.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_before_apt-install.sh.tmpl
@@ -13,24 +13,10 @@ set -o pipefail
 # Turn on traces, useful while debugging but commented out by default
 #set -o xtrace
 
-# apt-transport-https needed to install vscode - https://code.visualstudio.com/docs/setup/linux#_debian-and-ubuntu-based-distributions
-# [[ $debs := list
-     "curl"
-     "git"
-     "fonts-powerline"
-     "gnome-tweaks"
-     "wl-clipboard"
-     "zsh"
-     "apt-transport-https"
-     "code"
-     "build-essential"
-     "rclone"
-     "vim-runtime"
-     "vim-gui-common"
-]]
+# [[ $debs := .linux_os_admin.debs ]]
 
 # [[- if .full ]]
-  # [[- $debs = concat $debs (list "docker.io") -]]
+  # [[- $debs = concat $debs .linux_os_admin.full_debs -]]
 # [[- end ]]
 
 # curl -fsL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | base64

--- a/home/.chezmoiscripts/run_onchange_before_brew-install.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_before_brew-install.sh.tmpl
@@ -14,120 +14,26 @@ set -o pipefail
 
 export PATH=# [[ includeTemplate "path" | trim | quote ]]
 
-# [[- $brews := list
-      "go"
-      "fzf"
-      "dive"
-      "jq"
-      "git"
-      "htop"
-      "tree"
-      "curl"
-      "direnv"
-      "pandoc"
-      "ipcalc"
-      "powerline-go"
-      "terraform"
-      "terragrunt"
-      "packer"
-      "kubernetes-cli"
-      "kubectx"
-      "stern"
-      "k9s"
-      "vault"
-      "chezmoi"
-      "helm"
-      "pv"
-      "rustup-init"
-      "jrockway/tap/jlog"
-      "tealdeer"
-]]
+# [[- $brews := .all_os.brews ]]
 # TODO need to verify that neo4j no longer needs admin access on a mac
 # [[ $casks := list -]]
-# [[ $taps := list "jrockway/tap" -]]
+# [[ $taps := .all_os.taps -]]
 # [[ $mases := dict -]]
 
 # [[- if .full -]]
-# [[-   $brews = concat $brews (list
-        "ansible"
-        "awscli"
-        "azure-cli"
-        "openjdk@17"
-        "maven"
-        "pgcli"
-        "neo4j"
-      )
--]]
+# [[-   $brews = concat $brews .all_os.full_brews -]]
 # [[- end -]]
 
-
 # [[- if eq .chezmoi.os "darwin" -]]
-# [[-   $casks = concat $casks (list
-        "hammerspoon"
-        "stats"
-        "firefox"
-        "google-chrome"
-        "visual-studio-code"
-        "jetbrains-toolbox"
-        "iterm2"
-        "keeweb"
-        "font-liberation-mono-for-powerline"
-        "slack"
-      )
--]]
-# [[/*
-# Temporarily needed until https://github.com/Homebrew/homebrew-core/pull/97394
-# Re-add `"dockutil"` to brews list when merged
-*/]]
-# [[-   $casks = concat $casks (list
-       "hpedrorodrigues/tools/dockutil"
-      )
--]]
-
-# [[/*
-# readline - .inputrc
-# blueutil - used by Hammerspoon scripts
-# dockutil - manipulate the dock
-# svn - Needed by font-liberation-mono-for-powerline, for some reason
-*/]]
-# [[-   $brews = concat $brews (list
-      "bash-completion"
-      "readline"
-      "watch"
-      "blueutil"
-      "svn"
-      )
--]]
-
-# [[/*
-# For font-liberation-mono-for-powerline
-*/]]
-# [[-   $taps = concat $taps (list
-      "homebrew/cask-fonts"
-      )
--]]
+# [[-   $casks = concat $casks .mac_os.casks -]]
+# [[-   $brews = concat $brews .mac_os.brews -]]
+# [[-   $taps = concat $taps .mac_os.taps -]]
 
 # [[-   if .full -]]
-# [[-     $casks = concat $casks (list
-          "google-cloud-sdk"
-          "drawio"
-          "libreoffice"
-          "gimp"
-          "inkscape"
-        )
--]]
+# [[-     $casks = concat $casks .mac_os.full_casks -]]
 # [[-     if .admin -]]
-# [[-       $casks = concat $casks (list
-            "docker"
-          )
--]]
-# [[/*
-# mas needs admin permissions depending on what it installs
-*/]]
-# [[-       $brews = concat $brews (list
-            "mas"
-          )
--]]
+# [[-       $casks = concat $casks .mac_os_admin.full_casks -]]
+# [[-       $brews = concat $brews .mac_os_admin.full_brews -]]
 # [[-     end -]]
 # [[-   end -]]
 # [[- end -]]


### PR DESCRIPTION
Move the list of packages to install via homebrew into the data file so that the brew-install script is smaller, more readable, and doesn't contain anything that a validator would be confused with.