### PR TITLE
Fix CI by making WezTerm full only

### DIFF
--- a/home/.chezmoidata.toml
+++ b/home/.chezmoidata.toml
@@ -82,7 +82,7 @@ full_casks = [
 ]
 
 [linux_os_admin]
-brews = [
+full_brews = [
   "wezterm",
 ]
 taps = [

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -10,3 +10,7 @@ Library
 .config/tealdeer
 .local/share
 {{ end }}
+{{ if or (ne .chezmoi.os "linux") (not .full) }}
+.local/share/applications
+.local/share/icons
+{{ end }}

--- a/home/.chezmoiscripts/run_onchange_before_apt-install.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_before_apt-install.sh.tmpl
@@ -20,7 +20,7 @@ set -o pipefail
 # [[- end ]]
 
 # curl -fsL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | base64
-cat <<EOPGP | base64 --decode | sudo tee /etc/apt/keyrings/packages.microsoft.gpg
+cat <<EOPGP | base64 --decode | sudo tee /etc/apt/keyrings/packages.microsoft.gpg > /dev/null
 mQENBFYxWIwBCADAKoZhZlJxGNGWzqV+1OG1xiQeoowKhssGAKvd+buXCGISZJwTLXZqIcIiLP7p
 qdcZWtE9bSc7yBY2MalDp9Liu0KekywQ6VVX1T72NPf5Ev6x6DLV7aVWsCzUAF+eb7DC9fPuFLEd
 xmOEYoPjzrQ7cCnSV4JQxAqhU4T6OjbvRazGl3agOeizPXmRljMtUUttHQZnRhtlzkmwIrUivbfF

--- a/home/.chezmoiscripts/run_onchange_before_brew-install.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_before_brew-install.sh.tmpl
@@ -36,8 +36,10 @@ export PATH=# [[ includeTemplate "path" | trim | quote ]]
 # [[-     end ]]
 # [[-   end ]]
 # [[- else if eq .chezmoi.os "linux" ]]
-# [[-   $brews = concat $brews .linux_os_admin.brews -]]
 # [[-   $taps = concat $taps .linux_os_admin.taps -]]
+# [[-   if .full ]]
+# [[-     $brews = concat $brews .linux_os_admin.full_brews ]]
+# [[-   end ]]
 # [[- end ]]
 
 brew bundle --no-lock --file=/dev/stdin <<EOF


### PR DESCRIPTION
Only install WezTerm in 'full' mode as it's an AppImage so depends on FUSE to work. Also avoid outputting GPG key to avoid breaking terminals.