### PR TITLE
Only generate wezterm shell complete if present

### DIFF
--- a/home/.chezmoiscripts/linux/run_onchange_before_zzz_brew-install.sh.tmpl
+++ b/home/.chezmoiscripts/linux/run_onchange_before_zzz_brew-install.sh.tmpl
@@ -18,6 +18,6 @@ brew bundle --no-lock --file=/dev/stdin <<EOF
 tap "wez/wezterm-linuxbrew"
 
 # [[ if .full -]]
-brew "wezterm"
+brew "wezterm" # [[/* wezterm is an AppImage which needs FUSE to run */]]
 # [[- end ]]
 EOF

--- a/home/private_dot_local/fpath/_wezterm.tmpl
+++ b/home/private_dot_local/fpath/_wezterm.tmpl
@@ -1,1 +1,4 @@
-{{ output (joinPath .brew.prefix "bin" "wezterm") "shell-completion" "--shell" "zsh" | trim }}
+{{- $path := joinPath .brew.prefix "bin" "wezterm" -}}
+{{- if stat $path }}
+{{- output (joinPath .brew.prefix "bin" "wezterm") "shell-completion" "--shell" "zsh" | trim }}
+{{- end }}


### PR DESCRIPTION
Wezterm requires FUSE which isn't present in CI, so the call fails on Ubuntu.