### PR TITLE
Drop Go patch version

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/wjam/dotfiles/tests
 
-go 1.21.1
+go 1.21
 
 require (
 	github.com/gruntwork-io/terratest v0.44.0


### PR DESCRIPTION
Dependabot no longer requires the patch version

https://github.com/dependabot/dependabot-core/issues/7895